### PR TITLE
Fix relative paths not working

### DIFF
--- a/Source/HLSLMaterialRuntime/Private/HLSLMaterialFunctionLibrary.cpp
+++ b/Source/HLSLMaterialRuntime/Private/HLSLMaterialFunctionLibrary.cpp
@@ -16,10 +16,14 @@ FString UHLSLMaterialFunctionLibrary::GetFilePath() const
 FString UHLSLMaterialFunctionLibrary::GetFilePath(const FString& InFilePath)
 {
 	FString FullPath;
-	if (!FPackageName::TryConvertLongPackageNameToFilename(InFilePath, FullPath))
+	
+	if (FPackageName::TryConvertLongPackageNameToFilename(InFilePath, FullPath))
 	{
-		return InFilePath;
+		return FullPath;
 	}
+	
+	FullPath = FPaths::ConvertRelativePathToFull(InFilePath);
+	
 	return FullPath;
 }
 


### PR DESCRIPTION
When UHLSLMaterialFunctionLibrary::OnDirectoryChanged is called array of FFileChangeData has paths that are always full, not relative.

Filepath in HLSLMaterialFunctionLibrary is stored as relative filepath when possible. Which is good as this allowes for having shared hlsl directory in the project for all project users.

But when OnDirectoryChanged is called with those full paths it fails to find matching files.

With this change GetFilePath always returns full, not relative path