### PR TITLE
Resolve local includes

### DIFF
--- a/Source/HLSLMaterialEditor/Private/HLSLMaterialFunctionLibraryEditor.cpp
+++ b/Source/HLSLMaterialEditor/Private/HLSLMaterialFunctionLibraryEditor.cpp
@@ -63,7 +63,8 @@ TSharedRef<FVirtualDestructor> FHLSLMaterialFunctionLibraryEditor::CreateWatcher
 	FString Text;
 	if (TryLoadFileToString(Text, Library.GetFilePath()))
 	{
-		for (const FHLSLMaterialParser::FInclude& Include : FHLSLMaterialParser::GetIncludes(Text))
+		const FString ShaderPath = FPaths::GetPath(Library.GetFilePath());
+		for (const FHLSLMaterialParser::FInclude& Include : FHLSLMaterialParser::GetIncludes(ShaderPath, Text))
 		{
 			if (!Include.DiskPath.IsEmpty())
 			{
@@ -99,7 +100,7 @@ void FHLSLMaterialFunctionLibraryEditor::Generate(UHLSLMaterialFunctionLibrary& 
 	
 	FString BaseHash;
 	TArray<FString> IncludeFilePaths;
-	for (const FHLSLMaterialParser::FInclude& Include : FHLSLMaterialParser::GetIncludes(Text))
+	for (const FHLSLMaterialParser::FInclude& Include : FHLSLMaterialParser::GetIncludes(FPaths::GetPath(FullPath), Text))
 	{
 		IncludeFilePaths.Add(Include.VirtualPath);
 

--- a/Source/HLSLMaterialEditor/Private/HLSLMaterialParser.h
+++ b/Source/HLSLMaterialEditor/Private/HLSLMaterialParser.h
@@ -21,6 +21,6 @@ public:
 		FString VirtualPath;
 		FString DiskPath;
 	};
-	static TArray<FInclude> GetIncludes(const FString& Text);
+	static TArray<FInclude> GetIncludes(const FString& ShaderPath, const FString& Text);
 	static TArray<FCustomDefine> GetDefines(const FString& Text);
 };


### PR DESCRIPTION
Hey, me again 😄 

I propose small improvement to includes parsing that allows working with paths that IDEs have less problems with.

When using IDEs like Rider for developing shaders they often have problems with finding includes when included as virtual paths.

See for example https://youtrack.jetbrains.com/issue/RIDER-69615

This can be often worked around when working with global shaders by using relative paths to virtual shader location.

This cannot be done same way for code generated with HLSLMaterial.

This change adds fallback mechanism when we find that include path isn't real virtual path.
We try to check if this path is relative path to our hlsl file and if it is we try to find it in virtual mappings.