### PR TITLE
Fix compilation on UE5.0 release branch

### DIFF
--- a/Source/HLSLMaterialEditor/Private/HLSLMaterialEditorModule.cpp
+++ b/Source/HLSLMaterialEditor/Private/HLSLMaterialEditorModule.cpp
@@ -16,9 +16,20 @@ public:
 
 	//~ Begin IAssetTypeActions Interface
 	virtual FText GetName() const override { return INVTEXT("HLSL Material Function Library"); }
-	virtual uint32 GetCategories() override { return EAssetTypeCategories::MaterialsAndTextures; }
 	virtual FColor GetTypeColor() const override { return FColor(0, 175, 255); }
 	virtual UClass* GetSupportedClass() const override { return UHLSLMaterialFunctionLibrary::StaticClass(); }
+	virtual uint32 GetCategories() override
+	{
+#if ENGINE_MAJOR_VERSION >= 5
+		// We want to support both 5.0EA and 5.0 release
+		// As far as I found they have exactly the same version values in defines so we cannot check for that.
+		// 5.0 release added EAssetTypeCategories::Materials but EA still has MaterialsAndTextures category
+		// They both have the same numerical value in the enum so a hacky solution for now is just to use raw value.
+		return 1 << 2;
+#else
+		return EAssetTypeCategories::MaterialsAndTextures;
+#endif
+	}
 
 	virtual bool HasActions(const TArray<UObject*>&InObjects) const override { return true; }
 	virtual void GetActions(const TArray<UObject*>&InObjects, FMenuBuilder & MenuBuilder) override

--- a/Source/HLSLMaterialEditor/Private/HLSLMaterialFunctionGenerator.cpp
+++ b/Source/HLSLMaterialEditor/Private/HLSLMaterialFunctionGenerator.cpp
@@ -742,7 +742,7 @@ bool FHLSLMaterialFunctionGenerator::ParseDefaultValue(const FString& DefaultVal
 {
 	const FString FloatPattern = R"_(\s*((?:[0-9]*[.])?[0-9]*)f?\s*)_";
 
-	const auto TryParseFloat = [&](const FString& String, float& OutFloatValue)
+	const auto TryParseFloat = [&](const FString& String, auto& OutFloatValue)
 	{
 		FRegexPattern RegexPattern("^" + FloatPattern + "$");
 		FRegexMatcher RegexMatcher(RegexPattern, String);

--- a/Source/HLSLMaterialEditor/Private/HLSLMaterialShaderInfo.cpp
+++ b/Source/HLSLMaterialEditor/Private/HLSLMaterialShaderInfo.cpp
@@ -2,7 +2,7 @@
 
 #include "HLSLMaterialShaderInfo.h"
 
-#if ENGINE_VERSION >= 427
+#if ENABLE_PERMUTATION_WINDOW
 #include "IMaterialEditor.h"
 #include "IPropertyTable.h"
 #include "MaterialEditorModule.h"

--- a/Source/HLSLMaterialEditor/Private/HLSLMaterialShaderInfo.h
+++ b/Source/HLSLMaterialEditor/Private/HLSLMaterialShaderInfo.h
@@ -8,6 +8,12 @@
 
 class IMaterialEditor;
 
+#if ENGINE_VERSION >= 427 && ENGINE_MAJOR_VERSION < 5
+#define ENABLE_PERMUTATION_WINDOW 1
+#else
+#define ENABLE_PERMUTATION_WINDOW 0
+#endif
+
 UCLASS(Transient, Within=MaterialInterface)
 class UHLSLMaterialShaderInfoLayout : public UObject
 {
@@ -50,12 +56,12 @@ public:
 		}
 	}
 	
-#if ENGINE_VERSION >= 427
+#if ENABLE_PERMUTATION_WINDOW
 	virtual void PostEditChangeProperty(FPropertyChangedEvent& PropertyChangedEvent) override;
 #endif
 };
 
-#if ENGINE_VERSION >= 427
+#if ENABLE_PERMUTATION_WINDOW
 class FHLSLMaterialShaderInfo
 {
 public:


### PR DESCRIPTION
Those changes fix compilation on UE5.0 release branch.

Pretty minor but had to fully disable permutation window feature and do a little hack in 8b86ea6335547965f558ebe9064ca59b8da88fc5 to keep support for UE5 Early Access.