### PR TITLE
Added support for structs.

### DIFF
--- a/Source/HLSLMaterialEditor/Private/HLSLMaterialFunctionGenerator.cpp
+++ b/Source/HLSLMaterialEditor/Private/HLSLMaterialFunctionGenerator.cpp
@@ -35,6 +35,7 @@ FString FHLSLMaterialFunctionGenerator::GenerateFunction(
 	const TArray<FString>& IncludeFilePaths,
 	const TArray<FCustomDefine>& AdditionalDefines,
 	FHLSLMaterialFunction Function,
+	TArray<FString>& Structs,
 	FMaterialUpdateContext& UpdateContext)
 {
 	TSoftObjectPtr<UMaterialFunction>* MaterialFunctionPtr = Library.MaterialFunctions.FindByPredicate([&](TSoftObjectPtr<UMaterialFunction> InFunction)
@@ -460,7 +461,7 @@ FString FHLSLMaterialFunctionGenerator::GenerateFunction(
 		MaterialExpressionCustom->MaterialExpressionGuid = FGuid::NewGuid();
 		MaterialExpressionCustom->bCollapsed = true;
 		MaterialExpressionCustom->OutputType = CMOT_Float1;
-		MaterialExpressionCustom->Code = GenerateFunctionCode(Library, Function, Declarations);
+		MaterialExpressionCustom->Code = GenerateFunctionCode(Library, Function, Structs, Declarations);
 		MaterialExpressionCustom->MaterialExpressionEditorX = 500;
 		MaterialExpressionCustom->MaterialExpressionEditorY = 200 * Width;
 		MaterialExpressionCustom->IncludeFilePaths = IncludeFilePaths;
@@ -738,9 +739,15 @@ FString FHLSLMaterialFunctionGenerator::FPin::ParseTypeAndDefaultValue()
 	return {};
 }
 
-FString FHLSLMaterialFunctionGenerator::GenerateFunctionCode(const UHLSLMaterialFunctionLibrary& Library, const FHLSLMaterialFunction& Function, const FString& Declarations)
+FString FHLSLMaterialFunctionGenerator::GenerateFunctionCode(const UHLSLMaterialFunctionLibrary& Library, const FHLSLMaterialFunction& Function, const TArray<FString>& Structs, const FString& Declarations)
 {
-	FString Code = Function.Body.Replace(TEXT("return"), TEXT("return 0.f"));
+	FString Code;
+	for (const auto s : Structs)
+	{
+		Code += s;
+	}
+	
+	Code += Function.Body.Replace(TEXT("return"), TEXT("return 0.f"));
 
 	if (Library.bAccurateErrors)
 	{

--- a/Source/HLSLMaterialEditor/Private/HLSLMaterialFunctionGenerator.h
+++ b/Source/HLSLMaterialEditor/Private/HLSLMaterialFunctionGenerator.h
@@ -18,6 +18,7 @@ public:
 		const TArray<FString>& IncludeFilePaths,
 		const TArray<FCustomDefine>& AdditionalDefines,
 		FHLSLMaterialFunction Function,
+		TArray<FString>& Structs,
 		FMaterialUpdateContext& UpdateContext);
 
 private:
@@ -61,7 +62,7 @@ private:
 	static constexpr const TCHAR* META_Expose = TEXT("Expose");
 	static constexpr const TCHAR* META_Category = TEXT("Category");
 
-	static FString GenerateFunctionCode(const UHLSLMaterialFunctionLibrary& Library, const FHLSLMaterialFunction& Function, const FString& Declarations);
+	static FString GenerateFunctionCode(const UHLSLMaterialFunctionLibrary& Library, const FHLSLMaterialFunction& Function, const TArray<FString>& Structs, const FString& Declarations);
 	static bool ParseDefaultValue(const FString& DefaultValue, int32 Dimension, FVector4& OutValue);
 	static FString GenerateTooltip(const FString& ParamName, const FString& FunctionComment);
 	static TMap<FString, FString> GenerateMetadata(const FString& Metadata);

--- a/Source/HLSLMaterialEditor/Private/HLSLMaterialFunctionLibraryEditor.cpp
+++ b/Source/HLSLMaterialEditor/Private/HLSLMaterialFunctionLibraryEditor.cpp
@@ -128,8 +128,10 @@ void FHLSLMaterialFunctionLibraryEditor::Generate(UHLSLMaterialFunctionLibrary& 
 	}
 
 	TArray<FHLSLMaterialFunction> Functions;
+	TArray<FString> Structs;
+	
 	{
-		const FString Error = FHLSLMaterialParser::Parse(Library, Text, Functions);
+		const FString Error = FHLSLMaterialParser::Parse(Library, Text, Functions, Structs);
 		if (!Error.IsEmpty())
 		{
 			FHLSLMaterialMessages::ShowError(TEXT("Parsing failed: %s"), *Error);
@@ -151,7 +153,8 @@ void FHLSLMaterialFunctionLibraryEditor::Generate(UHLSLMaterialFunctionLibrary& 
 			Library, 
 			IncludeFilePaths, 
 			AdditionalDefines, 
-			Function, 
+			Function,
+			Structs,
 			UpdateContext);
 
 		if (!Error.IsEmpty())

--- a/Source/HLSLMaterialEditor/Private/HLSLMaterialParser.h
+++ b/Source/HLSLMaterialEditor/Private/HLSLMaterialParser.h
@@ -14,7 +14,8 @@ public:
 	static FString Parse(
 		const UHLSLMaterialFunctionLibrary& Library, 
 		FString Text, 
-		TArray<FHLSLMaterialFunction>& OutFunctions);
+		TArray<FHLSLMaterialFunction>& OutFunctions,
+		TArray<FString>& OutStructs);
 
 	struct FInclude
 	{


### PR DESCRIPTION
At the current state adding structs to the code breaks parsing, especially structs with functions which is the only easy way of adding non-material function "libraries" to the code node in UE4, i.e:

```
struct Functions 
{
    float4 SomeLocalFunction(float4 A, float4 B)
    {
        return lerp(A, B, 0.25);
    } 
};


void MaterialFunc(
    float4 A,
    float4 B
    out float4 Color)
{
    Functions fun;

    Color = fun.SomeLocalFunction(A, B);
}
```

If file contains multiple material functions, structs will be added to all of the code nodes.